### PR TITLE
Adding a version tag to the migration

### DIFF
--- a/lib/generators/keepr/migration/templates/migration.rb
+++ b/lib/generators/keepr/migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class KeeprMigration < ActiveRecord::Migration
+class KeeprMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table Keepr::Group, force: true do |t|
       t.integer    :target, :null => false


### PR DESCRIPTION
This is needed in Rails 5.0 else the migration will fail with
`StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for`