### PR TITLE
fix issue of amount given as string (for example from a form with nest…

### DIFF
--- a/lib/keepr/posting.rb
+++ b/lib/keepr/posting.rb
@@ -27,9 +27,9 @@ class Keepr::Posting < ActiveRecord::Base
     return unless amount
 
     if credit?
-      self.raw_amount = -amount
+      self.raw_amount = -amount.to_f
     elsif debit?
-      self.raw_amount =  amount
+      self.raw_amount =  amount.to_f
     end
   end
 
@@ -58,9 +58,9 @@ class Keepr::Posting < ActiveRecord::Base
     @side ||= SIDE_DEBIT
 
     if credit?
-      self.raw_amount = -value
+      self.raw_amount = -value.to_f
     else
-      self.raw_amount = value
+      self.raw_amount = value.to_f
     end
   end
 


### PR DESCRIPTION
…ed attributes)

When submiting parameters through a web form in the form:
`{
                         "date" => "2018-06-15",
                      "subject" => "",
                         "note" => "",
    "keepr_postings_attributes" => {
        "0" => {
                        "side" => "debit",
                      "amount" => "100",
            "keepr_account_id" => "17442"
        },
        "1" => {
                        "side" => "credit",
                      "amount" => "100",
            "keepr_account_id" => "16660"
        }
    }
}`

There is an amount_mismatch error. 