### PR TITLE
Fix migration_generator.rb

### DIFF
--- a/lib/generators/keepr/migration/migration_generator.rb
+++ b/lib/generators/keepr/migration/migration_generator.rb
@@ -15,7 +15,7 @@ module Keepr
     end
 
     def self.next_migration_number(dirname)
-      if ActiveRecord::Base.timestamped_migrations
+      if ActiveRecord.timestamped_migrations
         Time.now.utc.strftime('%Y%m%d%H%M%S')
       else
         format('%.3d', (current_migration_number(dirname) + 1))

--- a/lib/generators/keepr/migration/migration_generator.rb
+++ b/lib/generators/keepr/migration/migration_generator.rb
@@ -15,11 +15,22 @@ module Keepr
     end
 
     def self.next_migration_number(dirname)
-      if ActiveRecord.timestamped_migrations
+      if timestamped_migrations?
         Time.now.utc.strftime('%Y%m%d%H%M%S')
       else
         format('%.3d', (current_migration_number(dirname) + 1))
       end
+    end
+
+    def self.timestamped_migrations?
+      (
+        ActiveRecord::Base.respond_to?(:timestamped_migrations) &&
+          ActiveRecord::Base.timestamped_migrations
+      ) ||
+        (
+          ActiveRecord.respond_to?(:timestamped_migrations) &&
+            ActiveRecord.timestamped_migrations
+        )
     end
   end
 end


### PR DESCRIPTION
This fixes a compatibility bug with Rails 7.1.2. 

`ActiveRecord::Base.timestamped_migrations` is not a valid method, but ` ActiveRecord.timestamped_migrations` is.

https://www.rubydoc.info/docs/rails/ActiveRecord:timestamped_migrations